### PR TITLE
Add rsc support

### DIFF
--- a/celltypist/annotate.py
+++ b/celltypist/annotate.py
@@ -1,6 +1,6 @@
 from . import classifier
 from .models import Model
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 import numpy as np
 import pandas as pd
 from anndata import AnnData
@@ -15,7 +15,8 @@ def annotate(filename: Union[AnnData,str] = "",
              p_thres: float = 0.5,
              majority_voting: bool = False,
              over_clustering: Optional[Union[str, list, tuple, np.ndarray, pd.Series, pd.Index]] = None,
-             min_prop: float = 0) -> classifier.AnnotationResult:
+             min_prop: float = 0,
+             device: Literal["cpu","gpu"] = "cpu") -> classifier.AnnotationResult:
     """
     Run the prediction and (optional) majority voting to annotate the input dataset.
 
@@ -63,6 +64,9 @@ def annotate(filename: Union[AnnData,str] = "",
         Ignored if `majority_voting` is set to `False`.
         Subcluster that fails to pass this proportion threshold will be assigned `'Heterogeneous'`.
         (Default: 0)
+    device
+        Device to run the `overclustering` on. Choose from `'cpu'` for `scanpy` or `'gpu'` for `rapids-singlecell`.
+        (Default: `'cpu'`)
 
     Returns
     ----------
@@ -76,7 +80,7 @@ def annotate(filename: Union[AnnData,str] = "",
     #load model
     lr_classifier = model if isinstance(model, Model) else Model.load(model)
     #construct Classifier class
-    clf = classifier.Classifier(filename = filename, model = lr_classifier, transpose = transpose_input, gene_file = gene_file, cell_file = cell_file)
+    clf = classifier.Classifier(filename = filename, model = lr_classifier, transpose = transpose_input, gene_file = gene_file, cell_file = cell_file, device=device)
     #predict
     predictions = clf.celltype(mode = mode, p_thres = p_thres)
     if not majority_voting:

--- a/celltypist/classifier.py
+++ b/celltypist/classifier.py
@@ -425,8 +425,7 @@ class Classifier():
                 rsc.pp.highly_variable_genes(adata, n_top_genes = min([2500, adata.n_vars]))
             adata = adata[:, adata.var.highly_variable].copy()
             rsc.pp.scale(adata, max_value=10)
-            rsc.tl.pca(adata, n_comps=50)
-            rsc.get.anndata_to_CPU(adata)
+            rsc.pp.pca(adata, n_comps=50)
         rsc.pp.neighbors(adata, n_neighbors=10, n_pcs=50)
         return adata.obsm['X_pca'], adata.obsp['connectivities'], adata.obsp['distances'], adata.uns['neighbors']
 

--- a/celltypist/classifier.py
+++ b/celltypist/classifier.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 import scanpy as sc
 from anndata import AnnData
 import numpy as np
@@ -258,10 +258,11 @@ class Classifier():
     model
         A :class:`~celltypist.models.Model` object that wraps the logistic Classifier and the StandardScaler.
     """
-    def __init__(self, filename: Union[AnnData,str] = "", model: Union[Model,str] = "", transpose: bool = False, gene_file: Optional[str] = None, cell_file: Optional[str] = None):
+    def __init__(self, filename: Union[AnnData,str] = "", model: Union[Model,str] = "", transpose: bool = False, gene_file: Optional[str] = None, cell_file: Optional[str] = None, device: Literal["cpu", "gpu"] = "cpu"):
         if isinstance(model, str):
             model = Model.load(model)
         self.model = model
+        self.device = device
         if not filename:
             logger.warn(f"📭 No input file provided to the classifier")
             return
@@ -402,6 +403,33 @@ class Classifier():
         sc.pp.neighbors(adata, n_neighbors=10, n_pcs=50)
         return adata.obsm['X_pca'], adata.obsp['connectivities'], adata.obsp['distances'], adata.uns['neighbors']
 
+    @staticmethod
+    def _construct_neighbor_graph_rsc(adata: AnnData) -> tuple:
+        """Construct a neighborhood graph. This function is for internal use."""
+        # fix for adata.uns['log1p']['base'] error
+        try:
+            import rapids_singlecell as rsc
+        except ImportError:
+            raise ImportError(
+                    "🛑 rapids_singlecell is required for the construction of the neighborhood graph on the GPU. Please install rsc by running `pip install rapids_singlecell`")
+        if 'log1p' in adata.uns.keys():
+            if isinstance(adata.uns['log1p'], dict) and 'base' not in adata.uns['log1p'].keys():
+                adata.uns['log1p']['base'] = None
+
+        if 'X_pca' not in adata.obsm.keys():
+            if adata.X[:1000].min() < 0:
+                adata = adata.raw.to_adata()
+            rsc.get.anndata_to_GPU(adata)
+            if 'highly_variable' not in adata.var:
+                rsc.pp.filter_genes(adata, min_count=5, verbose=False)
+                rsc.pp.highly_variable_genes(adata, n_top_genes = min([2500, adata.n_vars]))
+            adata = adata[:, adata.var.highly_variable].copy()
+            rsc.pp.scale(adata, max_value=10)
+            rsc.tl.pca(adata, n_comps=50)
+            rsc.get.anndata_to_CPU(adata)
+        rsc.pp.neighbors(adata, n_neighbors=10, n_pcs=50)
+        return adata.obsm['X_pca'], adata.obsp['connectivities'], adata.obsp['distances'], adata.uns['neighbors']
+
     def over_cluster(self, resolution: Optional[float] = None) -> pd.Series:
         """
         Over-clustering input data with a canonical Scanpy pipeline. A neighborhood graph will be used (or constructed if not found) for the over-clustering.
@@ -417,10 +445,20 @@ class Classifier():
         :class:`~pandas.Series`
             A :class:`~pandas.Series` object showing the over-clustering result.
         """
+        if self.device == "gpu":
+            try:
+                import rapids_singlecell as rsc
+            except ImportError:
+                logger.info(
+                    "🛑 rapids_singlecell is required for running on the GPU. Please install rsc. Defaulting back to CPU")
+                self.device = "cpu"
         if 'connectivities' not in self.adata.obsp:
             logger.info("👀 Can not detect a neighborhood graph, will construct one before the over-clustering")
             adata = self.adata.copy()
-            self.adata.obsm['X_pca'], self.adata.obsp['connectivities'], self.adata.obsp['distances'], self.adata.uns['neighbors'] = Classifier._construct_neighbor_graph(adata)
+            if self.device == "gpu":
+                self.adata.obsm['X_pca'], self.adata.obsp['connectivities'], self.adata.obsp['distances'], self.adata.uns['neighbors'] = Classifier._construct_neighbor_graph_rsc(adata)
+            else:
+                self.adata.obsm['X_pca'], self.adata.obsp['connectivities'], self.adata.obsp['distances'], self.adata.uns['neighbors'] = Classifier._construct_neighbor_graph(adata)
         else:
             logger.info("👀 Detected a neighborhood graph in the input object, will run over-clustering on the basis of it")
         if resolution is None:
@@ -437,7 +475,10 @@ class Classifier():
             else:
                 resolution = 30
         logger.info(f"⛓️ Over-clustering input data with resolution set to {resolution}")
-        sc.tl.leiden(self.adata, resolution=resolution, key_added='over_clustering')
+        if self.device == "gpu":
+            rsc.tl.leiden(self.adata, resolution=resolution, key_added='over_clustering')
+        else:
+            sc.tl.leiden(self.adata, resolution=resolution, key_added='over_clustering')
         return self.adata.obs.pop('over_clustering')
 
     @staticmethod

--- a/celltypist/classifier.py
+++ b/celltypist/classifier.py
@@ -411,7 +411,7 @@ class Classifier():
             import rapids_singlecell as rsc
         except ImportError:
             raise ImportError(
-                    "🛑 rapids_singlecell is required for the construction of the neighborhood graph on the GPU. Please install rsc by running `pip install rapids_singlecell`")
+                    "🛑 rapids_singlecell is required for the construction of the neighborhood graph on the GPU. Please install rsc by running `pip install rapids-singlecell`")
         if 'log1p' in adata.uns.keys():
             if isinstance(adata.uns['log1p'], dict) and 'base' not in adata.uns['log1p'].keys():
                 adata.uns['log1p']['base'] = None


### PR DESCRIPTION
This adds support for rapids-singlecell for the `over clustering` #110 . The results might differ a bit since rsc uses a brute-force knn approach and the leiden clustering is also slightly different. 

The overclustering step is now for 200k cells 15x faster (3min vs 12s). 

It's also set up in a way where when rsc fails to import it will default back to scanpy.

Please don't merge this yet since it uses the syntax that will be released with rapids-singlecell 0.10.0. This will come out shortly after scanpy 1.10.0